### PR TITLE
WOOC-990 add css rule (overwrite magento default margin on p.note)

### DIFF
--- a/view/adminhtml/layout/default.xml
+++ b/view/adminhtml/layout/default.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <css src="Payplug_Payments::css/custom.css"/>
+    </head>
+</page>

--- a/view/adminhtml/web/css/custom.css
+++ b/view/adminhtml/web/css/custom.css
@@ -1,0 +1,3 @@
+p.note{
+    margin-bottom: 0px !important;
+}


### PR DESCRIPTION
# ⚠️ Requirements
Reviewer, please take a look at those requirements before merging on `master` :

- [x] Check that plugin version has been upgrated and are identical in both `composer.json` and `Helper/Config.php` files

