### PR TITLE
SMP-2211 fix for explode with null parameter

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -459,6 +459,10 @@ class Config extends AbstractHelper
         $minAmountsConfig = $this->getConfigValue($amountPrefix . 'min_amounts', ScopeInterface::SCOPE_STORE, $storeId, $path);
         $maxAmountsConfig = $this->getConfigValue($amountPrefix . 'max_amounts', ScopeInterface::SCOPE_STORE, $storeId, $path);
 
+        if(empty($minAmountsConfig) || empty($maxAmountsConfig)){
+            return false;
+        }
+
         foreach (explode(';', $minAmountsConfig) as $amountCur) {
             $cur = [];
             if (preg_match('/^([A-Z]{3}):([0-9]*)$/', $amountCur, $cur)) {


### PR DESCRIPTION
# ⚠️ Requirements
Reviewer, please take a look at those requirements before merging on `master` :

- [x] Check that plugin version has been upgrated and are identical in both `composer.json` and `Helper/Config.php` files

