### PR TITLE
MAG-368: Fix payment_method is not defined

### DIFF
--- a/Controller/Payment/PaymentReturn.php
+++ b/Controller/Payment/PaymentReturn.php
@@ -93,7 +93,7 @@ class PaymentReturn extends AbstractPayment
      */
     public function isOneyPending(?Payment $payment): bool
     {
-        if ($payment) {
+        if ($payment && isset($payment->payment_method)) {
             $paymentMethod = $payment->payment_method;
             if ($payment->is_paid === false && isset($paymentMethod['is_pending']) && isset($paymentMethod['type'])) {
                 return (str_contains($paymentMethod['type'], 'oney') && $paymentMethod['is_pending'] === true);


### PR DESCRIPTION
changelog: fixed

# ⚠️ Requirements
Reviewer, please take a look at those requirements before merging on `master` :

- [X] Check that plugin version has been upgrated and are identical in both `composer.json` and `Helper/Config.php` files

