### PR TITLE
#244 Addition of a CSP whitelist policy to avoid the crash of the renderer components depending on external script in the checkout.

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -32,5 +32,10 @@
                 <value id="secure-magenta" type="host">https://secure-magenta.dalenys.com</value>
             </values>
         </policy>
+        <policy id="script-src-elem">
+            <values>
+                <value id="payplug-api" type="host">cdn.payplug.com</value>
+            </values>
+        </policy>
     </policies>
 </csp_whitelist>


### PR DESCRIPTION
Hello,

Following the following issue https://github.com/payplug/payplug-magento2/issues/244, the payplug components are crashing with obscure error message if the external dependency of the component is blocked by the CSP policy.

As the dependency is required for the module to work, I'm assuming that it requires to be present in the csp_whitelist.xml of the module.

As it's a fix and not a feature, I'm asking the merge to the master branch and not to the v4.3.0 branch.

Kind Regards,
Baptiste
