### PR TITLE
Release/v4.3.0 to master

### DIFF
--- a/Block/Info.php
+++ b/Block/Info.php
@@ -50,7 +50,7 @@ class Info extends BaseInfo
         $order = $this->getInfo()->getOrder();
 
         try {
-            $payment = $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $payment = $orderPayment->retrieve($orderPayment->getScopeId($order), $orderPayment->getScope($order));
         } catch (PayplugException $e) {
             $this->payplugLogger->error($e->__toString());
             return [];

--- a/Block/Info.php
+++ b/Block/Info.php
@@ -50,7 +50,7 @@ class Info extends BaseInfo
         $order = $this->getInfo()->getOrder();
 
         try {
-            $payment = $orderPayment->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $payment = $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
         } catch (PayplugException $e) {
             $this->payplugLogger->error($e->__toString());
             return [];

--- a/Block/InstallmentPlanInfo.php
+++ b/Block/InstallmentPlanInfo.php
@@ -11,6 +11,7 @@ use Magento\Store\Model\ScopeInterface;
 use Payplug\Exception\PayplugException;
 use Payplug\Payments\Helper\Data;
 use Payplug\Payments\Logger\Logger;
+use Payplug\Payments\Model\OrderInstallmentPlanRepository;
 use Payplug\Payments\Model\OrderPaymentRepository;
 
 class InstallmentPlanInfo extends Info
@@ -22,6 +23,7 @@ class InstallmentPlanInfo extends Info
         Data $payplugHelper,
         Logger $payplugLogger,
         private OrderPaymentRepository $orderPaymentRepository,
+        private OrderInstallmentPlanRepository $orderInstallmentPaymentRepository,
         private FormKey $formKey,
         array $data = []
     ) {
@@ -52,7 +54,7 @@ class InstallmentPlanInfo extends Info
         $order = $this->getInfo()->getOrder();
 
         try {
-            $orderPayment = $this->orderPaymentRepository->get($orderIncrementId, 'order_id');
+            $orderPayment = $this->orderInstallmentPaymentRepository->get($orderIncrementId, 'order_id');
             $installmentPlan = $orderInstallmentPlan->retrieve($orderPayment->getScopeId($order), $orderPayment->getScope($order));
         } catch (PayplugException $e) {
             $this->payplugLogger->error($e->__toString());

--- a/Block/InstallmentPlanInfo.php
+++ b/Block/InstallmentPlanInfo.php
@@ -52,7 +52,7 @@ class InstallmentPlanInfo extends Info
         $order = $this->getInfo()->getOrder();
 
         try {
-            $installmentPlan = $orderInstallmentPlan->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $installmentPlan = $orderInstallmentPlan->retrieve($orderInstallmentPlan->getScopeId($order), $orderInstallmentPlan->getScope($order));
         } catch (PayplugException $e) {
             $this->payplugLogger->error($e->__toString());
             return [];
@@ -98,7 +98,7 @@ class InstallmentPlanInfo extends Info
 
                 try {
                     $orderPayment = $this->orderPaymentRepository->get($paymentId, 'payment_id');
-                    $payment = $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+                    $payment = $orderPayment->retrieve($orderInstallmentPlan->getScopeId($order), $orderInstallmentPlan->getScope($order));
                     $paymentInfo['details'] = $this->buildPaymentDetails($payment, $order);
                     $paymentInfo['status'] = $paymentInfo['details']['Status'];
                 } catch (NoSuchEntityException $e) {

--- a/Block/InstallmentPlanInfo.php
+++ b/Block/InstallmentPlanInfo.php
@@ -52,7 +52,8 @@ class InstallmentPlanInfo extends Info
         $order = $this->getInfo()->getOrder();
 
         try {
-            $installmentPlan = $orderInstallmentPlan->retrieve($orderInstallmentPlan->getScopeId($order), $orderInstallmentPlan->getScope($order));
+            $orderPayment = $this->orderPaymentRepository->get($orderIncrementId, 'order_id');
+            $installmentPlan = $orderInstallmentPlan->retrieve($orderPayment->getScopeId($order), $orderPayment->getScope($order));
         } catch (PayplugException $e) {
             $this->payplugLogger->error($e->__toString());
             return [];
@@ -98,7 +99,7 @@ class InstallmentPlanInfo extends Info
 
                 try {
                     $orderPayment = $this->orderPaymentRepository->get($paymentId, 'payment_id');
-                    $payment = $orderPayment->retrieve($orderInstallmentPlan->getScopeId($order), $orderInstallmentPlan->getScope($order));
+                    $payment = $orderPayment->retrieve($orderPayment->getScopeId($order), $orderPayment->getScope($order));
                     $paymentInfo['details'] = $this->buildPaymentDetails($payment, $order);
                     $paymentInfo['status'] = $paymentInfo['details']['Status'];
                 } catch (NoSuchEntityException $e) {

--- a/Block/InstallmentPlanInfo.php
+++ b/Block/InstallmentPlanInfo.php
@@ -52,7 +52,7 @@ class InstallmentPlanInfo extends Info
         $order = $this->getInfo()->getOrder();
 
         try {
-            $installmentPlan = $orderInstallmentPlan->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $installmentPlan = $orderInstallmentPlan->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
         } catch (PayplugException $e) {
             $this->payplugLogger->error($e->__toString());
             return [];
@@ -98,7 +98,7 @@ class InstallmentPlanInfo extends Info
 
                 try {
                     $orderPayment = $this->orderPaymentRepository->get($paymentId, 'payment_id');
-                    $payment = $orderPayment->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+                    $payment = $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
                     $paymentInfo['details'] = $this->buildPaymentDetails($payment, $order);
                     $paymentInfo['status'] = $paymentInfo['details']['Status'];
                 } catch (NoSuchEntityException $e) {

--- a/Block/OndemandInfo.php
+++ b/Block/OndemandInfo.php
@@ -49,7 +49,7 @@ class OndemandInfo extends Info
 
         foreach ($orderPayments as $orderPayment) {
             try {
-                $payment = $orderPayment->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+                $payment = $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
                 $paymentInfoDetails = $this->buildPaymentDetails($payment, $order);
 
                 $paymentInfo = [

--- a/Block/OndemandInfo.php
+++ b/Block/OndemandInfo.php
@@ -49,7 +49,7 @@ class OndemandInfo extends Info
 
         foreach ($orderPayments as $orderPayment) {
             try {
-                $payment = $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+                $payment = $orderPayment->retrieve($orderPayment->getScopeId($order), $orderPayment->getScope($order));
                 $paymentInfoDetails = $this->buildPaymentDetails($payment, $order);
 
                 $paymentInfo = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.0-beta](https://github.com/payplug/payplug-magento2/releases/tag/v4.3.0-beta) - 2025-03-17
+## [4.3.0-rc](https://github.com/payplug/payplug-magento2/releases/tag/v4.3.0-rc) - 2025-03-17
 
 ### Features
 
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synchronize orders status with Payplug servers post payment 
 - Compatibility with php 8.1 and Magento 2.4.4 and above. (SMP-3032)
 
-**[View diff](https://github.com/payplug/payplug-magento2/compare/v4.2.0...release/v4.3.0-beta)**
+**[View diff](https://github.com/payplug/payplug-magento2/compare/v4.2.0...release/v4.3.0-rc)**
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.0](https://github.com/payplug/payplug-magento2/releases/tag/4.3.0) - 2025-02-03
+
+### Features
+
+- Add a queue system feature 
+- Synchronize orders status with Payplug servers post payment 
+- Compatibility with php 8.1 and Magento 2.4.4 and above. (SMP-3032)
+
+**[View diff](https://github.com/payplug/payplug-magento2/compare/v4.2.0...release/v4.3.0)**
+
+### Added
+
+- Add queue system payment feature [#246](https://github.com/payplug/payplug-magento2/pull/246)
+
+### Changed
+
+### Removed
+
+- Removed the unions type in the base code. [#246](https://github.com/payplug/payplug-magento2/pull/246)
+
 ## [4.2.0](https://github.com/payplug/payplug-magento2/releases/tag/4.2.0) - 2025-01-13
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.0-RC](https://github.com/payplug/payplug-magento2/releases/tag/v4.3.0-RC) - 2025-03-17
+## [4.3.0](https://github.com/payplug/payplug-magento2/releases/tag/v4.3.0) - 2025-03-19
 
 ### Features
 
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synchronize orders status with Payplug servers post payment 
 - Compatibility with php 8.1 and Magento 2.4.4 and above. (SMP-3032)
 
-**[View diff](https://github.com/payplug/payplug-magento2/compare/v4.2.0...release/v4.3.0-RC)**
+**[View diff](https://github.com/payplug/payplug-magento2/compare/v4.2.0...release/v4.3.0)**
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.0-rc](https://github.com/payplug/payplug-magento2/releases/tag/v4.3.0-rc) - 2025-03-17
+## [4.3.0-RC](https://github.com/payplug/payplug-magento2/releases/tag/v4.3.0-RC) - 2025-03-17
 
 ### Features
 
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synchronize orders status with Payplug servers post payment 
 - Compatibility with php 8.1 and Magento 2.4.4 and above. (SMP-3032)
 
-**[View diff](https://github.com/payplug/payplug-magento2/compare/v4.2.0...release/v4.3.0-rc)**
+**[View diff](https://github.com/payplug/payplug-magento2/compare/v4.2.0...release/v4.3.0-RC)**
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.0](https://github.com/payplug/payplug-magento2/releases/tag/4.3.0) - 2025-02-03
+## [4.3.0-beta](https://github.com/payplug/payplug-magento2/releases/tag/4.3.0) - 2025-03-17
 
 ### Features
 
+- Support Magento 2.4.7
 - Add a queue system feature 
 - Synchronize orders status with Payplug servers post payment 
 - Compatibility with php 8.1 and Magento 2.4.4 and above. (SMP-3032)
@@ -19,11 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add queue system payment feature [#246](https://github.com/payplug/payplug-magento2/pull/246)
 
-### Changed
-
 ### Removed
 
 - Removed the unions type in the base code. [#246](https://github.com/payplug/payplug-magento2/pull/246)
+
+### Fixed
+
+- Fix the scripts for the 2.4.7 with the secureHtmlRenderer class [#253](https://github.com/payplug/payplug-magento2/pull/253)
 
 ## [4.2.0](https://github.com/payplug/payplug-magento2/releases/tag/4.2.0) - 2025-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.3.0-beta](https://github.com/payplug/payplug-magento2/releases/tag/4.3.0) - 2025-03-17
+## [4.3.0-beta](https://github.com/payplug/payplug-magento2/releases/tag/v4.3.0-beta) - 2025-03-17
 
 ### Features
 
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synchronize orders status with Payplug servers post payment 
 - Compatibility with php 8.1 and Magento 2.4.4 and above. (SMP-3032)
 
-**[View diff](https://github.com/payplug/payplug-magento2/compare/v4.2.0...release/v4.3.0)**
+**[View diff](https://github.com/payplug/payplug-magento2/compare/v4.2.0...release/v4.3.0-beta)**
 
 ### Added
 

--- a/Controller/Adminhtml/Order/NewPaymentLinkForm.php
+++ b/Controller/Adminhtml/Order/NewPaymentLinkForm.php
@@ -61,8 +61,10 @@ class NewPaymentLinkForm extends AdminOrder
 
     /**
      * OnDemand new payment link view
+     *
+     * @return Redirect|Page
      */
-    public function execute(): Redirect|Page
+    public function execute()
     {
         $resultRedirect = $this->resultRedirectFactory->create();
 

--- a/Controller/ApplePay/GetTransactionData.php
+++ b/Controller/ApplePay/GetTransactionData.php
@@ -4,15 +4,30 @@ declare(strict_types=1);
 
 namespace Payplug\Payments\Controller\ApplePay;
 
+use Magento\Checkout\Model\Session;
+use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
-use Magento\Framework\Exception\PaymentException;
-use Magento\Sales\Model\Order;
+use Magento\Sales\Model\OrderFactory;
 use Payplug\Exception\PayplugException;
 use Payplug\Payments\Controller\Payment\AbstractPayment;
+use Payplug\Payments\Helper\Data;
+use Payplug\Payments\Logger\Logger;
+use Payplug\Payments\Service\GetCurrentOrder;
 
 class GetTransactionData extends AbstractPayment
 {
+    public function __construct(
+        Context $context,
+        Session $checkoutSession,
+        OrderFactory $salesOrderFactory,
+        Logger $logger,
+        Data $payplugHelper,
+        protected GetCurrentOrder $getCurrentOrder
+    ) {
+        parent::__construct($context, $checkoutSession, $salesOrderFactory, $logger, $payplugHelper);
+    }
+
     /**
      * Retrieve PayPlug Apple Pay transaction data
      */
@@ -27,7 +42,7 @@ class GetTransactionData extends AbstractPayment
         ];
 
         try {
-            $order = $this->getLastOrder();
+            $order = $this->getCurrentOrder->execute();
             $merchandSession = $order->getPayment()->getAdditionalInformation('merchand_session');
             $order->getPayment()->unsAdditionalInformation('merchand_session');
 
@@ -58,27 +73,5 @@ class GetTransactionData extends AbstractPayment
 
             return $response;
         }
-    }
-
-    /**
-     * Get last order
-     *
-     * @throws \Exception
-     */
-    private function getLastOrder(): Order
-    {
-        $lastIncrementId = $this->getCheckout()->getLastRealOrderId();
-
-        if (!$lastIncrementId) {
-            throw new \Exception('Could not retrieve last order id');
-        }
-        $order = $this->salesOrderFactory->create();
-        $order->loadByIncrementId($lastIncrementId);
-
-        if (!$order->getId()) {
-            throw new \Exception(sprintf('Could not retrieve order with id %s', $lastIncrementId));
-        }
-
-        return $order;
     }
 }

--- a/Controller/ApplePay/UpdateTransaction.php
+++ b/Controller/ApplePay/UpdateTransaction.php
@@ -4,15 +4,30 @@ declare(strict_types=1);
 
 namespace Payplug\Payments\Controller\ApplePay;
 
+use Magento\Checkout\Model\Session;
+use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
-use Magento\Framework\Exception\PaymentException;
-use Magento\Sales\Model\Order;
+use Magento\Sales\Model\OrderFactory;
 use Payplug\Exception\PayplugException;
 use Payplug\Payments\Controller\Payment\AbstractPayment;
+use Payplug\Payments\Helper\Data;
+use Payplug\Payments\Logger\Logger;
+use Payplug\Payments\Service\GetCurrentOrder;
 
 class UpdateTransaction extends AbstractPayment
 {
+    public function __construct(
+        Context $context,
+        Session $checkoutSession,
+        OrderFactory $salesOrderFactory,
+        Logger $logger,
+        Data $payplugHelper,
+        protected GetCurrentOrder $getCurrentOrder
+    ) {
+        parent::__construct($context, $checkoutSession, $salesOrderFactory, $logger, $payplugHelper);
+    }
+
     /**
      * Update PayPlug Apple Pay transaction data
      */
@@ -26,7 +41,7 @@ class UpdateTransaction extends AbstractPayment
         ]);
 
         try {
-            $order = $this->getLastOrder();
+            $order = $this->getCurrentOrder->execute();
             $token = $this->getRequest()->getParam('token');
             if (empty($token)) {
                 throw new \Exception('Could not retrieve token');
@@ -61,27 +76,5 @@ class UpdateTransaction extends AbstractPayment
 
             return $response;
         }
-    }
-
-    /**
-     * Get last order
-     *
-     * @throws \Exception
-     */
-    private function getLastOrder(): Order
-    {
-        $lastIncrementId = $this->getCheckout()->getLastRealOrderId();
-
-        if (!$lastIncrementId) {
-            throw new \Exception('Could not retrieve last order id');
-        }
-        $order = $this->salesOrderFactory->create();
-        $order->loadByIncrementId($lastIncrementId);
-
-        if (!$order->getId()) {
-            throw new \Exception(sprintf('Could not retrieve order with id %s', $lastIncrementId));
-        }
-
-        return $order;
     }
 }

--- a/Controller/Customer/CardDelete.php
+++ b/Controller/Customer/CardDelete.php
@@ -29,8 +29,12 @@ class CardDelete extends Action
 
     /**
      * Check customer authentication
+     *
+     * @param RequestInterface $request
+     *
+     * @return ResponseInterface|Page|Redirect
      */
-    public function dispatch(RequestInterface $request): ResponseInterface|Page|Redirect
+    public function dispatch(RequestInterface $request)
     {
         if (!$this->customerSession->authenticate()) {
             $this->_actionFlag->set('', 'no-dispatch', true);

--- a/Controller/Customer/CardList.php
+++ b/Controller/Customer/CardList.php
@@ -24,8 +24,12 @@ class CardList extends Action
 
     /**
      * Check customer authentication
+     *
+     * @param RequestInterface $request
+     *
+     * @return ResponseInterface|Page
      */
-    public function dispatch(RequestInterface $request): ResponseInterface|Page
+    public function dispatch(RequestInterface $request)
     {
         if (!$this->customerSession->authenticate()) {
             $this->_actionFlag->set('', 'no-dispatch', true);

--- a/Controller/Payment/AbstractPayment.php
+++ b/Controller/Payment/AbstractPayment.php
@@ -27,8 +27,10 @@ abstract class AbstractPayment extends Action
 
     /**
      * Get quote
+     *
+     * @return CartInterface|Quote
      */
-    protected function getQuote(): CartInterface|Quote
+    protected function getQuote()
     {
         return $this->getCheckout()->getQuote();
     }

--- a/Controller/Payment/Cancel.php
+++ b/Controller/Payment/Cancel.php
@@ -8,11 +8,11 @@ use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\Data\Form\FormKey\Validator;
-use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderFactory;
 use Magento\Sales\Model\OrderRepository;
 use Payplug\Payments\Helper\Data;
 use Payplug\Payments\Logger\Logger;
+use Payplug\Payments\Service\GetCurrentOrder;
 
 class Cancel extends AbstractPayment
 {
@@ -24,7 +24,8 @@ class Cancel extends AbstractPayment
         Data $payplugHelper,
         private OrderRepository $orderRepository,
         private Validator $formKeyValidator,
-        private RequestInterface $request
+        private RequestInterface $request,
+        private GetCurrentOrder $getCurrentOrder
     ) {
         parent::__construct($context, $checkoutSession, $salesOrderFactory, $logger, $payplugHelper);
     }
@@ -49,22 +50,7 @@ class Cancel extends AbstractPayment
         }
 
         try {
-            $lastIncrementId = $this->getCheckout()->getLastRealOrderId();
-
-            if (!$lastIncrementId) {
-                $this->logger->error('Could not retrieve last order id');
-
-                return $resultRedirect->setPath($redirectUrlCart);
-            }
-            $order = $this->salesOrderFactory->create();
-            /** @var $order Order */
-            $order->loadByIncrementId($lastIncrementId);
-
-            if (!$order->getId()) {
-                $this->logger->error(sprintf('Could not retrieve order with id %s', $lastIncrementId));
-
-                return $resultRedirect->setPath($redirectUrlCart);
-            }
+            $order = $this->getCurrentOrder->execute();
 
             $this->payplugHelper->cancelOrderAndInvoice($order);
 

--- a/Controller/Payment/CheckPayment.php
+++ b/Controller/Payment/CheckPayment.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 
 namespace Payplug\Payments\Controller\Payment;
 
+use Magento\Checkout\Model\Session;
+use Magento\Framework\App\Action\Context;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Exception\AlreadyExistsException;
@@ -12,10 +14,25 @@ use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\OrderFactory;
 use Payplug\Payments\Exception\OrderAlreadyProcessingException;
+use Payplug\Payments\Helper\Data;
+use Payplug\Payments\Logger\Logger;
+use Payplug\Payments\Service\GetCurrentOrder;
 
 class CheckPayment extends AbstractPayment
 {
+    public function __construct(
+        Context $context,
+        Session $checkoutSession,
+        OrderFactory $salesOrderFactory,
+        Logger $logger,
+        Data $payplugHelper,
+        protected GetCurrentOrder $getCurrentOrder
+    ) {
+        parent::__construct($context, $checkoutSession, $salesOrderFactory, $logger, $payplugHelper);
+    }
+
     /**
      * Retrieve PayPlug Standard payment url
      *
@@ -30,8 +47,8 @@ class CheckPayment extends AbstractPayment
     {
         $response = $this->resultFactory->create(ResultFactory::TYPE_JSON);
 
-        $paymentId = $this->getRequest()->getParam("payment_id");
-        $order = $this->getLastOrder();
+        $paymentId = $this->getRequest()->getParam('payment_id');
+        $order = $this->getCurrentOrder->execute();
         $storeId = $order->getStoreId();
 
         if (empty($paymentId)) {
@@ -57,28 +74,5 @@ class CheckPayment extends AbstractPayment
         $response->setData($data);
 
         return $response;
-    }
-
-    /**
-     * @return Order
-     *
-     * @throws \Exception
-     */
-    private function getLastOrder(): Order
-    {
-        $lastIncrementId = $this->getCheckout()->getLastRealOrderId();
-
-        if (!$lastIncrementId) {
-            throw new \Exception('Could not retrieve last order id');
-        }
-
-        $order = $this->salesOrderFactory->create();
-        $order->loadByIncrementId($lastIncrementId);
-
-        if (!$order->getId()) {
-            throw new \Exception(sprintf('Could not retrieve order with id %s', $lastIncrementId));
-        }
-
-        return $order;
     }
 }

--- a/Controller/Payment/Ipn.php
+++ b/Controller/Payment/Ipn.php
@@ -61,8 +61,10 @@ class Ipn extends AbstractPayment
      * Action called when IPN is received
      *
      * Can update order status when payment or refund notification is received
+     *
+     * @return Redirect|ResultInterface|Json
      */
-    public function execute(): Redirect|ResultInterface|Json
+    public function execute()
     {
         $this->logger->info('--- Starting IPN Action ---');
 
@@ -136,8 +138,12 @@ class Ipn extends AbstractPayment
 
     /**
      * Process debug ipn call
+     *
+     * @param Raw $response
+     *
+     * @return Raw|Json|ResultInterface
      */
-    private function processDebugCall(Raw $response): Raw|Json|ResultInterface
+    private function processDebugCall(Raw $response)
     {
         $this->logger->info('This is a debug call.');
         $cid = (int) $this->payplugConfig->getConfigValue('company_id');

--- a/Controller/Payment/PaymentReturn.php
+++ b/Controller/Payment/PaymentReturn.php
@@ -54,7 +54,7 @@ class PaymentReturn extends AbstractPayment
 
             $lastIncrementId = $order->getIncrementId();
             $orderPaymentModel = $this->payplugHelper->getOrderPayment((string)$lastIncrementId);
-            $payment = $orderPaymentModel->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $payment = $orderPaymentModel->retrieve($orderPaymentModel->getScopeId($order), $orderPaymentModel->getScope($order));
 
             // If this is the deferred standard paiement then return the user on the success checkout
             if (!$payment->is_paid && $this->isAuthorizedOnlyStandardPayment($order)) {

--- a/Cron/CheckOrderConsistency.php
+++ b/Cron/CheckOrderConsistency.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payplug\Payments\Cron;
+
+use Magento\Framework\Api\SearchCriteriaBuilderFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Sales\Api\Data\OrderPaymentInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\OrderPaymentRepositoryInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Store\Model\ScopeInterface;
+use Payplug\Exception\PayplugException;
+use Payplug\Payments\Helper\Data;
+use Payplug\Payments\Logger\Logger;
+use Payplug\Resource\Payment as ResourcePayment;
+
+class CheckOrderConsistency
+{
+    /**
+     * Check all payplug orders up to X hours old in order to update them
+     */
+    public const PAST_HOURS_TO_CHECK = 4;
+
+    public function __construct(
+        private Logger $logger,
+        private SearchCriteriaBuilderFactory $searchCriteriaBuilderFactory,
+        private OrderPaymentRepositoryInterface $paymentRepository,
+        private OrderRepositoryInterface $orderRepository,
+        private Data $payplugHelper
+    ) {
+    }
+
+    /**
+     * Loop through all payplug orders from the past 4hours & awaiting payment
+     */
+    public function execute(): void
+    {
+        $this->logger->info('Running the CheckOrderConsistency cron');
+
+        $magentoOrdersPayments = $this->getCheckablePayplugOrderPaymentsList();
+
+        if (count($magentoOrdersPayments) >= 0) {
+            $this->logger->info(
+                sprintf(
+                    '%s payplug related orders are less than %s hours old and are awaiting payments, we will try to update them.',
+                    count($magentoOrdersPayments),
+                    self::PAST_HOURS_TO_CHECK
+                )
+            );
+        } else {
+            $this->logger->info('No payplug related orders found.');
+        }
+
+        // Check if the orders awaiting paiement are in the payplug processing state in the API
+        foreach ($magentoOrdersPayments as $magentoOrdersPayment) {
+            $this->logger->info(sprintf('Trying to update order_id %s', $magentoOrdersPayment->getParentId()));
+            $magentoOrder = $this->orderRepository->get($magentoOrdersPayment->getParentId());
+            $payplugPayment = $this->getPayplugPaymentFromApiByIncrementId($magentoOrder);
+            if ($payplugPayment) {
+                $paymentId = $payplugPayment->id ?: '';
+                $payplugOrderPayment = $this->payplugHelper->getOrderPayment($magentoOrder->getIncrementId());
+                // If the paiment is not processing in the API it mean that the state of the order can be updated
+                if (!$payplugOrderPayment->isProcessing($payplugPayment)) {
+                    $this->logger->info(
+                        sprintf(
+                            'Payplug payment_id %s is not processing in the API and will be updated in magento.',
+                            $paymentId
+                        )
+                    );
+                    $this->payplugHelper->checkPaymentFailureAndAbortPayment($magentoOrder);
+                    $this->payplugHelper->updateOrder($magentoOrder);
+                } else {
+                    // Payment is still processing (not paid and not failure on the api) we just log it
+                    $this->logger->info(
+                        sprintf(
+                            'Payplug payment_id %s is still processing in the API for magento order_id %s.',
+                            $paymentId,
+                            $magentoOrder->getEntityId()
+                        )
+                    );
+                }
+            } else {
+                // The magento order couldn't be matched to any payplug order
+                $this->logger->info(
+                    sprintf(
+                        'No payplug payment found for the magento order %s.',
+                    $magentoOrder->getEntityId()
+                    )
+                );
+            }
+        }
+
+        $this->logger->info(sprintf('The %s cron is finished.', get_class($this)));
+    }
+
+    public function getPayplugPaymentFromApiByIncrementId(OrderInterface $magentoOrder): ?ResourcePayment
+    {
+        try {
+            $payplugOrderPayment = $this->payplugHelper->getOrderPayment($magentoOrder->getIncrementId());
+        } catch (NoSuchEntityException $e) {
+            return null;
+        }
+
+        if (!$payplugOrderPayment->getId()) {
+            $this->logger->error('Cannot find a PayplugOrderPayment for the magento order %s.', $magentoOrder->getEntityId());
+
+            return null;
+        }
+
+        try {
+            $payment = $payplugOrderPayment->retrieve((int)$magentoOrder->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+        } catch (PayplugException $e) {
+            $this->logger->error($e->__toString());
+
+            return null;
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+            if (str_contains($e->getMessage(), 'Forbidden error')) {
+                $this->logger->error(
+                    sprintf(
+                        'The order entity id %s cannot be retrieved anymore from payplug Api.',
+                        $magentoOrder->getEntityId()
+                    )
+                );
+            }
+
+            return null;
+        }
+
+        return $payment;
+    }
+
+    /**
+     * Get all payplug orders from the past 4hours & awaiting payment
+     *
+     * @return OrderPaymentInterface[]|null
+     */
+    public function getCheckablePayplugOrderPaymentsList(): ?array
+    {
+        $delay = (new \DateTime())->modify('-' . self::PAST_HOURS_TO_CHECK . ' hours')->format('Y-m-d H:i:s');
+
+        // Get all the order within a said delay (sales_order table)
+        $searchOrderCriteria = $this->searchCriteriaBuilderFactory->create()
+            ->addFilter('created_at', $delay, 'gteq')
+            ->create();
+
+        $orderIds = $this->orderRepository->getList($searchOrderCriteria)->getAllIds();
+
+        if (empty($orderIds)) {
+            return [];
+        }
+
+        // From the orders, get all the matching order payment that are not paid and using the payplug method (sales_order_payment table)
+        $searchOrderPaymentCriteria = $this->searchCriteriaBuilderFactory->create()
+            ->addFilter('parent_id', $orderIds, 'in')
+            ->addFilter('method', '%payplug%', 'like')
+            ->addFilter('base_amount_paid', null, 'null')
+            ->create();
+
+        return $this->paymentRepository->getList($searchOrderPaymentCriteria)->getItems();
+    }
+}

--- a/Cron/CheckOrderConsistency.php
+++ b/Cron/CheckOrderConsistency.php
@@ -61,7 +61,7 @@ class CheckOrderConsistency
             if ($payplugPayment) {
                 $paymentId = $payplugPayment->id ?: '';
                 $payplugOrderPayment = $this->payplugHelper->getOrderPayment($magentoOrder->getIncrementId());
-                // If the paiment is not processing in the API it mean that the state of the order can be updated
+                // If the payment is not processing in the API it mean that the state of the order can be updated
                 if (!$payplugOrderPayment->isProcessing($payplugPayment)) {
                     $this->logger->info(
                         sprintf(

--- a/Gateway/Http/Client/InstallmentPlan/FetchTransactionInformation.php
+++ b/Gateway/Http/Client/InstallmentPlan/FetchTransactionInformation.php
@@ -21,7 +21,7 @@ class FetchTransactionInformation implements ClientInterface
 
         /** @var InstallmentPlan $orderInstallmentPlan */
         $orderInstallmentPlan = $data['installment_plan'];
-        $installmentPlan = $orderInstallmentPlan->retrieve($data['store_id']);
+        $installmentPlan = $orderInstallmentPlan->retrieve((int)$data['store_id']);
 
         return ['installment_plan' => $installmentPlan, 'order_installment_plan' => $orderInstallmentPlan];
     }

--- a/Gateway/Http/Client/InstallmentPlan/Refund.php
+++ b/Gateway/Http/Client/InstallmentPlan/Refund.php
@@ -52,7 +52,7 @@ class Refund implements ClientInterface
             $storeId = $data['store_id'];
             $amount = $data['amount'] * 100;
 
-            $installmentPlan = $orderInstallmentPlan->retrieve($storeId);
+            $installmentPlan = $orderInstallmentPlan->retrieve((int)$storeId);
 
             $schedules = $installmentPlan->schedule;
             $refunds = [];
@@ -69,7 +69,7 @@ class Refund implements ClientInterface
                         continue;
                     }
 
-                    $payment = $orderPayment->retrieve($storeId);
+                    $payment = $orderPayment->retrieve((int)$storeId);
                     $paymentAmount = $payment->amount - $payment->amount_refunded;
 
                     $amountToRefund = $amount;
@@ -90,7 +90,7 @@ class Refund implements ClientInterface
             }
 
             foreach ($refunds as $refund) {
-                $refund['orderPayment']->makeRefund($refund['amount'], $metadata, $storeId);
+                $refund['orderPayment']->makeRefund((float)$refund['amount'], $metadata, (int)$storeId);
             }
 
             return [];

--- a/Gateway/Http/Client/Standard/FetchTransactionInformation.php
+++ b/Gateway/Http/Client/Standard/FetchTransactionInformation.php
@@ -21,7 +21,7 @@ class FetchTransactionInformation implements ClientInterface
 
         /** @var Payment $orderPayment */
         $orderPayment = $data['payment'];
-        $payment = $orderPayment->retrieve($data['store_id']);
+        $payment = $orderPayment->retrieve((int)$data['store_id']);
 
         return ['payment' => $payment];
     }

--- a/Gateway/Http/Client/Standard/Refund.php
+++ b/Gateway/Http/Client/Standard/Refund.php
@@ -40,7 +40,7 @@ class Refund implements ClientInterface
             /** @var Payment $orderPayment */
             $orderPayment = $data['payment'];
             $metadata = ['reason' => "Refunded with Magento."];
-            $payment = $orderPayment->makeRefund($data['amount'], $metadata, $data['store_id']);
+            $payment = $orderPayment->makeRefund((float)$data['amount'], $metadata, (int)$data['store_id']);
 
             return ['payment' => $payment, 'order_payment' => $orderPayment];
         } catch (PayplugException $e) {

--- a/Gateway/Response/InstallmentPlan/FetchTransactionInformationHandler.php
+++ b/Gateway/Response/InstallmentPlan/FetchTransactionInformationHandler.php
@@ -121,7 +121,7 @@ class FetchTransactionInformationHandler implements HandlerInterface
                         $orderPayment->setPaymentId($paymentId);
                         $orderPayment->setIsSandbox(!$payplugInstallmentPlan->is_live);
                     }
-                    $payplugPayment = $orderPayment->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+                    $payplugPayment = $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
 
                     if ($payplugPayment->is_paid && !$orderPayment->isInstallmentPlanPaymentProcessed()) {
                         $this->sendOrderEmail($order);

--- a/Gateway/Response/InstallmentPlan/FetchTransactionInformationHandler.php
+++ b/Gateway/Response/InstallmentPlan/FetchTransactionInformationHandler.php
@@ -121,7 +121,7 @@ class FetchTransactionInformationHandler implements HandlerInterface
                         $orderPayment->setPaymentId($paymentId);
                         $orderPayment->setIsSandbox(!$payplugInstallmentPlan->is_live);
                     }
-                    $payplugPayment = $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+                    $payplugPayment = $orderPayment->retrieve($orderPayment->getScopeId($order), $orderPayment->getScope($order));
 
                     if ($payplugPayment->is_paid && !$orderPayment->isInstallmentPlanPaymentProcessed()) {
                         $this->sendOrderEmail($order);

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -34,7 +34,7 @@ class Config extends AbstractHelper
     public const PAYMENT_PAGE_EMBEDDED = 'embedded';
     public const PAYMENT_PAGE_INTEGRATED = 'integrated';
 
-    public const MODULE_VERSION = '4.2.0';
+    public const MODULE_VERSION = '4.3.0';
     public const STANDARD_PAYMENT_AUTHORIZATION_ONLY = 'authorize';
 
     private ?AdapterInterface $adapter = null;

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -380,9 +380,14 @@ class Config extends AbstractHelper
     }
 
     /**
-     * Get valid range of amount for a given currency
+     * @param string $isoCode
+     * @param int|null $storeId
+     * @param string|null $path
+     * @param string|null $amountPrefix
+     *
+     * @return array|bool
      */
-    public function getAmountsByCurrency(string $isoCode, ?int $storeId, ?string $path, ?string $amountPrefix = ''): array|bool
+    public function getAmountsByCurrency(string $isoCode, ?int $storeId, ?string $path, ?string $amountPrefix = '')
     {
         $minAmounts = [];
         $maxAmounts = [];

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -389,7 +389,7 @@ class Data extends AbstractHelper
     {
       $orderPayment = $this->getPaymentForOrder($order);
 
-      return $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+      return $orderPayment->retrieve($orderPayment->getScopeId($order), $orderPayment->getScope($order));
     }
 
     /**
@@ -419,7 +419,7 @@ class Data extends AbstractHelper
             if ($orderPayment === null) {
                 return;
             }
-            $payplugPayment = $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $payplugPayment = $orderPayment->retrieve($orderPayment->getScopeId($order), $orderPayment->getScope($order));
             if ($payplugPayment->failure &&
                 $payplugPayment->failure->code &&
                 strtolower($payplugPayment->failure->code ?? '') !== 'timeout'
@@ -451,7 +451,7 @@ class Data extends AbstractHelper
         $storeId = $order->getStoreId();
         if ($order->getPayment()->getMethod() === InstallmentPlan::METHOD_CODE) {
             $orderInstallmentPlan = $this->getOrderInstallmentPlan($order->getIncrementId());
-            $installmentPlan = $orderInstallmentPlan->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $installmentPlan = $orderInstallmentPlan->retrieve($orderInstallmentPlan->getScopeId($order), $orderInstallmentPlan->getScope($order));
             foreach ($installmentPlan->schedule as $schedule) {
                 if (!empty($schedule->payment_ids) && is_array($schedule->payment_ids)) {
                     $paymentId = $schedule->payment_ids[0];
@@ -586,7 +586,7 @@ class Data extends AbstractHelper
         $storeId = $order->getStoreId();
         $orderInstallmentPlan = $this->getOrderInstallmentPlan($order->getIncrementId());
         if ($cancelPayment) {
-            $installmentPlan = $orderInstallmentPlan->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $installmentPlan = $orderInstallmentPlan->retrieve($orderInstallmentPlan->getScopeId($order), $orderInstallmentPlan->getScope($order));
             foreach ($installmentPlan->schedule as $schedule) {
                 if (!empty($schedule->payment_ids) && is_array($schedule->payment_ids)) {
                     $paymentId = $schedule->payment_ids[0];
@@ -604,7 +604,7 @@ class Data extends AbstractHelper
             }
         }
         $orderInstallmentPlan->abort((int)$storeId);
-        $installmentPlan = $orderInstallmentPlan->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+        $installmentPlan = $orderInstallmentPlan->retrieve($orderPayment->getScopeId($order), $orderPayment->getScope($order));
         $this->updateInstallmentPlanStatus($orderInstallmentPlan, $installmentPlan);
     }
 
@@ -716,7 +716,7 @@ class Data extends AbstractHelper
     {
         /** @var Processing $orderProcessing */
         $orderProcessing = $this->orderProcessingFactory->create();
-        $orderProcessing->setOrderId($order->getId());
+        $orderProcessing->setOrderId($order->get());
         $date = new \DateTime();
         $orderProcessing->setCreatedAt($date->format('Y-m-d H:i:s'));
         $this->orderProcessingRepository->save($orderProcessing);
@@ -902,7 +902,7 @@ class Data extends AbstractHelper
             $payment = $this->getOrderPayment($order->getIncrementId());
         }
         /** @var Payment|OrderInstallmentPlan $payplugPayment */
-        $payplugPayment = $payment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+        $payplugPayment = $payment->retrieve($payment->getScopeId($order), $payment->getScope($order));
 
         if ($payplugPayment->failure) {
             return true;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -604,7 +604,7 @@ class Data extends AbstractHelper
             }
         }
         $orderInstallmentPlan->abort((int)$storeId);
-        $installmentPlan = $orderInstallmentPlan->retrieve($orderPayment->getScopeId($order), $orderPayment->getScope($order));
+        $installmentPlan = $orderInstallmentPlan->retrieve($orderInstallmentPlan->getScopeId($order), $orderInstallmentPlan->getScope($order));
         $this->updateInstallmentPlanStatus($orderInstallmentPlan, $installmentPlan);
     }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -80,7 +80,7 @@ class Data extends AbstractHelper
      * @return Payment
      * @throws NoSuchEntityException
      */
-    public function getOrderPayment(int|string $orderId): Payment
+    public function getOrderPayment($orderId): Payment
     {
         return $this->orderPaymentRepository->get($orderId, 'order_id');
     }
@@ -91,7 +91,7 @@ class Data extends AbstractHelper
      * @return Payment
      * @throws NoSuchEntityException
      */
-    public function getOrderPaymentByPaymentId(int|string $paymentId): Payment
+    public function getOrderPaymentByPaymentId($paymentId): Payment
     {
         return $this->orderPaymentRepository->get($paymentId, 'payment_id');
     }
@@ -102,7 +102,7 @@ class Data extends AbstractHelper
      * @return OrderInstallmentPlan
      * @throws NoSuchEntityException
      */
-    public function getOrderInstallmentPlan(int|string $orderId): OrderInstallmentPlan
+    public function getOrderInstallmentPlan($orderId): OrderInstallmentPlan
     {
         return $this->orderInstallmentPlanRepository->get($orderId, 'order_id');
     }
@@ -112,7 +112,7 @@ class Data extends AbstractHelper
      *
      * @return Payment|null
      */
-    public function getOrderLastPayment(int|string $orderId): ?Payment
+    public function getOrderLastPayment($orderId): ?Payment
     {
         $orderPayments = $this->getOrderPayments($orderId);
 
@@ -124,7 +124,7 @@ class Data extends AbstractHelper
      *
      * @return array|Payment[]
      */
-    public function getOrderPayments(int|string $orderId): array
+    public function getOrderPayments($orderId): array
     {
         /** @var SearchCriteriaInterface $criteria */
         $criteria = $this->searchCriteriaInterfaceFactory->create();
@@ -389,7 +389,7 @@ class Data extends AbstractHelper
     {
       $orderPayment = $this->getPaymentForOrder($order);
 
-      return $orderPayment->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+      return $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
     }
 
     /**
@@ -419,12 +419,12 @@ class Data extends AbstractHelper
             if ($orderPayment === null) {
                 return;
             }
-            $payplugPayment = $orderPayment->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $payplugPayment = $orderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
             if ($payplugPayment->failure &&
                 $payplugPayment->failure->code &&
                 strtolower($payplugPayment->failure->code ?? '') !== 'timeout'
             ) {
-                $orderPayment->abort($storeId);
+                $orderPayment->abort((int)$storeId);
             }
         } catch (HttpException $e) {
             $this->_logger->error('Could not abort payment', [
@@ -451,7 +451,7 @@ class Data extends AbstractHelper
         $storeId = $order->getStoreId();
         if ($order->getPayment()->getMethod() === InstallmentPlan::METHOD_CODE) {
             $orderInstallmentPlan = $this->getOrderInstallmentPlan($order->getIncrementId());
-            $installmentPlan = $orderInstallmentPlan->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $installmentPlan = $orderInstallmentPlan->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
             foreach ($installmentPlan->schedule as $schedule) {
                 if (!empty($schedule->payment_ids) && is_array($schedule->payment_ids)) {
                     $paymentId = $schedule->payment_ids[0];
@@ -586,7 +586,7 @@ class Data extends AbstractHelper
         $storeId = $order->getStoreId();
         $orderInstallmentPlan = $this->getOrderInstallmentPlan($order->getIncrementId());
         if ($cancelPayment) {
-            $installmentPlan = $orderInstallmentPlan->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $installmentPlan = $orderInstallmentPlan->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
             foreach ($installmentPlan->schedule as $schedule) {
                 if (!empty($schedule->payment_ids) && is_array($schedule->payment_ids)) {
                     $paymentId = $schedule->payment_ids[0];
@@ -596,15 +596,15 @@ class Data extends AbstractHelper
 
                     try {
                         $orderPayment = $this->getOrderPaymentByPaymentId($paymentId);
-                        $orderPayment->abort($storeId);
+                        $orderPayment->abort((int)$storeId);
                     } catch (NoSuchEntityException $e) {
                         // Payment was not found - no need to abort it
                     }
                 }
             }
         }
-        $orderInstallmentPlan->abort($storeId);
-        $installmentPlan = $orderInstallmentPlan->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+        $orderInstallmentPlan->abort((int)$storeId);
+        $installmentPlan = $orderInstallmentPlan->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
         $this->updateInstallmentPlanStatus($orderInstallmentPlan, $installmentPlan);
     }
 
@@ -617,7 +617,7 @@ class Data extends AbstractHelper
     public function cancelStandardPayment(Order $order): void
     {
         $orderPayment = $this->getOrderPayment($order->getIncrementId());
-        $orderPayment->abort($order->getStoreId());
+        $orderPayment->abort((int)$order->getStoreId());
     }
 
     /**
@@ -828,7 +828,7 @@ class Data extends AbstractHelper
      *
      * @return void
      */
-    public function refreshSalesGrid(int|string $orderId): void
+    public function refreshSalesGrid($orderId): void
     {
         $this->salesGrid->refresh($orderId);
     }
@@ -902,7 +902,7 @@ class Data extends AbstractHelper
             $payment = $this->getOrderPayment($order->getIncrementId());
         }
         /** @var Payment|OrderInstallmentPlan $payplugPayment */
-        $payplugPayment = $payment->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+        $payplugPayment = $payment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
 
         if ($payplugPayment->failure) {
             return true;

--- a/Helper/Ondemand.php
+++ b/Helper/Ondemand.php
@@ -91,7 +91,7 @@ class Ondemand extends AbstractHelper
             throw new PaymentException(__('Unable to find payment linked to order %1', $order->getIncrementId()));
         }
 
-        $payplugPayment = $lastOrderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+        $payplugPayment = $lastOrderPayment->retrieve($lastOrderPayment->getScopeId($order), $lastOrderPayment->getScope($order));
         if ($payplugPayment->is_paid) {
             $exceptionMessage = 'Last payment %1 has already been paid. ' .
                 'Please wait for the automatic notification or update the payment manually.';

--- a/Helper/Ondemand.php
+++ b/Helper/Ondemand.php
@@ -91,7 +91,7 @@ class Ondemand extends AbstractHelper
             throw new PaymentException(__('Unable to find payment linked to order %1', $order->getIncrementId()));
         }
 
-        $payplugPayment = $lastOrderPayment->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+        $payplugPayment = $lastOrderPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
         if ($payplugPayment->is_paid) {
             $exceptionMessage = 'Last payment %1 has already been paid. ' .
                 'Please wait for the automatic notification or update the payment manually.';
@@ -123,7 +123,7 @@ class Ondemand extends AbstractHelper
 
         $newTransaction = $this->ondemandBuilder->buildTransaction($orderAdapter, $payment, $quote);
 
-        $payplugPayment = $lastOrderPayment->abort($order->getStoreId());
+        $payplugPayment = $lastOrderPayment->abort((int)$order->getStoreId());
         if ($payplugPayment === null) {
             throw new PaymentException(__('Unable to abort payment %1', $lastOrderPayment->getPaymentId()));
         }

--- a/Helper/Transaction/AbstractBuilder.php
+++ b/Helper/Transaction/AbstractBuilder.php
@@ -35,8 +35,14 @@ abstract class AbstractBuilder extends AbstractHelper
 
     /**
      * Build PayPlug payment transaction
+     *
+     * @param OrderInterface|OrderAdapterInterface $order
+     * @param InfoInterface $payment
+     * @param CartInterface|Quote $quote
+     *
+     * @return array
      */
-    public function buildTransaction(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface|Quote $quote): array
+    public function buildTransaction($order, InfoInterface $payment, $quote): array
     {
         $transaction = array_merge(
             $this->buildAmountData($order),
@@ -54,8 +60,12 @@ abstract class AbstractBuilder extends AbstractHelper
 
     /**
      * Build amount data
+     *
+     * @param OrderInterface|OrderAdapterInterface $order
+     *
+     * @return int[]
      */
-    public function buildAmountData(OrderInterface|OrderAdapterInterface $order): array
+    public function buildAmountData($order): array
     {
         $unroundedAmount = $order?->getGrandTotalAmount() ?? $order?->getBaseGrandTotal() ?? 0;
 
@@ -68,8 +78,14 @@ abstract class AbstractBuilder extends AbstractHelper
 
     /**
      * Build customer data
+     *
+     * @param OrderInterface|OrderAdapterInterface $order
+     * @param InfoInterface $payment
+     * @param CartInterface|Quote $quote
+     *
+     * @return array
      */
-    public function buildCustomerData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface|Quote $quote): array
+    public function buildCustomerData($order, InfoInterface $payment, $quote): array
     {
         $language = $this->payplugConfig->getConfigValue(
             'code',
@@ -182,8 +198,13 @@ abstract class AbstractBuilder extends AbstractHelper
 
     /**
      * Build order data
+     *
+     * @param OrderInterface|OrderAdapterInterface $order
+     * @param CartInterface|Quote $quote
+     *
+     * @return array
      */
-    public function buildOrderData(OrderInterface|OrderAdapterInterface $order, CartInterface|Quote $quote): array
+    public function buildOrderData($order, $quote): array
     {
         $currency = $order->getCurrencyCode();
         $quoteId = $quote->getId();
@@ -209,8 +230,14 @@ abstract class AbstractBuilder extends AbstractHelper
 
     /**
      * Build payment data
+     *
+     * @param OrderInterface|OrderAdapterInterface $order
+     * @param InfoInterface $payment
+     * @param CartInterface $quote
+     *
+     * @return array
      */
-    public function buildPaymentData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface|Quote $quote): array
+    public function buildPaymentData($order, InfoInterface $payment, CartInterface $quote): array
     {
         $quoteId = $quote->getId();
         $storeId = $order->getStoreId();

--- a/Helper/Transaction/AmexBuilder.php
+++ b/Helper/Transaction/AmexBuilder.php
@@ -14,7 +14,7 @@ class AmexBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildPaymentData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildPaymentData($order, InfoInterface $payment, CartInterface $quote): array
     {
         $paymentData = parent::buildPaymentData($order, $payment, $quote);
         $paymentData['payment_method'] = 'american_express';

--- a/Helper/Transaction/ApplePayBuilder.php
+++ b/Helper/Transaction/ApplePayBuilder.php
@@ -15,7 +15,7 @@ class ApplePayBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildPaymentData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildPaymentData($order, InfoInterface $payment, CartInterface $quote): array
     {
         $merchandDomain = parse_url($this->scopeConfig->getValue('web/secure/base_url', ScopeInterface::SCOPE_STORE), PHP_URL_HOST);
 

--- a/Helper/Transaction/BancontactBuilder.php
+++ b/Helper/Transaction/BancontactBuilder.php
@@ -14,7 +14,7 @@ class BancontactBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildPaymentData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildPaymentData($order, InfoInterface $payment, CartInterface $quote): array
     {
         $paymentData = parent::buildPaymentData($order, $payment, $quote);
         $paymentData['payment_method'] = 'bancontact';

--- a/Helper/Transaction/IdealBuilder.php
+++ b/Helper/Transaction/IdealBuilder.php
@@ -14,7 +14,7 @@ class IdealBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildPaymentData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildPaymentData($order, InfoInterface $payment, CartInterface $quote): array
     {
         $paymentData = parent::buildPaymentData($order, $payment, $quote);
         $paymentData['payment_method'] = 'ideal';

--- a/Helper/Transaction/InstallmentPlanBuilder.php
+++ b/Helper/Transaction/InstallmentPlanBuilder.php
@@ -14,7 +14,7 @@ class InstallmentPlanBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildAmountData(OrderInterface|OrderAdapterInterface $order): array
+    public function buildAmountData($order): array
     {
         return [];
     }
@@ -22,7 +22,7 @@ class InstallmentPlanBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildPaymentData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildPaymentData($order, InfoInterface $payment, CartInterface $quote): array
     {
         $paymentData = parent::buildPaymentData($order, $payment, $quote);
         unset($paymentData['force_3ds']);

--- a/Helper/Transaction/MybankBuilder.php
+++ b/Helper/Transaction/MybankBuilder.php
@@ -14,7 +14,7 @@ class MybankBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildPaymentData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildPaymentData($order, InfoInterface $payment, CartInterface $quote): array
     {
         $paymentData = parent::buildPaymentData($order, $payment, $quote);
         $paymentData['payment_method'] = 'mybank';

--- a/Helper/Transaction/OndemandBuilder.php
+++ b/Helper/Transaction/OndemandBuilder.php
@@ -38,7 +38,7 @@ class OndemandBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildPaymentData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildPaymentData($order, InfoInterface $payment, CartInterface $quote): array
     {
         $paymentData = parent::buildPaymentData($order, $payment, $quote);
         unset($paymentData['hosted_payment']['return_url']);
@@ -97,7 +97,7 @@ class OndemandBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildTransaction(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface|Quote $quote): array
+    public function buildTransaction($order, InfoInterface $payment, $quote): array
     {
         $transaction = parent::buildTransaction($order, $payment, $quote);
 

--- a/Helper/Transaction/OneyBuilder.php
+++ b/Helper/Transaction/OneyBuilder.php
@@ -35,7 +35,7 @@ class OneyBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildTransaction(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildTransaction($order, InfoInterface $payment, $quote): array
     {
         $this->validateTransaction($order, $payment, $quote);
 
@@ -51,7 +51,7 @@ class OneyBuilder extends AbstractBuilder
      *
      * @throws LocalizedException
      */
-    private function validateTransaction(OrderAdapterInterface|OrderInterface $order, InfoInterface $payment, CartInterface $quote)
+    private function validateTransaction($order, InfoInterface $payment, CartInterface $quote)
     {
         try {
             $this->oneyHelper->oneyCheckoutValidation(
@@ -106,7 +106,7 @@ class OneyBuilder extends AbstractBuilder
      *
      * @throws \Exception
      */
-    private function validateBillingMobilePhone(OrderAdapterInterface|OrderInterface $order): void
+    private function validateBillingMobilePhone($order): void
     {
         $exceptionMessage = (string)__('Please fill in a mobile phone on your billing address.');
         $address = $order->getBillingAddress();
@@ -146,7 +146,7 @@ class OneyBuilder extends AbstractBuilder
      *
      * @throws LocalizedException
      */
-    private function buildCartContext(OrderInterface|OrderAdapterInterface $order, CartInterface $quote): array
+    private function buildCartContext($order, CartInterface $quote): array
     {
         $shippingMethod = $this->getShippingMethod($quote);
         $shippingMapping = $this->oneyHelper->getShippingMethodMapping($shippingMethod);
@@ -215,7 +215,7 @@ class OneyBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildCustomerData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildCustomerData($order, InfoInterface $payment, $quote): array
     {
         $customerData = parent::buildCustomerData($order, $payment, $quote);
 
@@ -252,7 +252,7 @@ class OneyBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildAmountData(OrderInterface|OrderAdapterInterface $order): array
+    public function buildAmountData($order): array
     {
         $amountData = parent::buildAmountData($order);
         $amountData['authorized_amount'] = $amountData['amount'];
@@ -264,7 +264,7 @@ class OneyBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildPaymentData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildPaymentData($order, InfoInterface $payment, CartInterface $quote): array
     {
         $paymentData = parent::buildPaymentData($order, $payment, $quote);
 

--- a/Helper/Transaction/SatispayBuilder.php
+++ b/Helper/Transaction/SatispayBuilder.php
@@ -14,7 +14,7 @@ class SatispayBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildPaymentData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildPaymentData($order, InfoInterface $payment, CartInterface $quote): array
     {
         $paymentData = parent::buildPaymentData($order, $payment, $quote);
         $paymentData['payment_method'] = 'satispay';

--- a/Helper/Transaction/StandardBuilder.php
+++ b/Helper/Transaction/StandardBuilder.php
@@ -35,7 +35,7 @@ class StandardBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildPaymentData(OrderInterface|OrderAdapterInterface $order, InfoInterface $payment, CartInterface $quote): array
+    public function buildPaymentData($order, InfoInterface $payment, CartInterface $quote): array
     {
         $paymentData = parent::buildPaymentData($order, $payment, $quote);
 
@@ -67,7 +67,7 @@ class StandardBuilder extends AbstractBuilder
     /**
      * @inheritdoc
      */
-    public function buildAmountData(OrderInterface|OrderAdapterInterface $order): array
+    public function buildAmountData($order): array
     {
         $amountData = parent::buildAmountData($order);
         if ($this->payplugConfig->isStandardPaymentModeDeferred()) {

--- a/Model/Order/InstallmentPlan.php
+++ b/Model/Order/InstallmentPlan.php
@@ -2,6 +2,8 @@
 
 namespace Payplug\Payments\Model\Order;
 
+use Magento\Framework\App\ScopeInterface as ScopeInterfaceDefault;
+use Magento\Sales\Model\Order;
 use Magento\Store\Model\ScopeInterface;
 use Payplug\Payments\Helper\Config;
 
@@ -152,6 +154,30 @@ class InstallmentPlan extends \Magento\Framework\Model\AbstractModel implements
     public function setStatus($status)
     {
         return $this->setData(self::STATUS, $status);
+    }
+
+    public function getScope(Order $order): string
+    {
+        if ($order->getStoreId()) {
+            return ScopeInterface::SCOPE_STORES;
+        } elseif ($order->getStore()->getWebsiteId()) {
+            return ScopeInterface::SCOPE_WEBSITES;
+        }
+
+        return ScopeInterfaceDefault::SCOPE_DEFAULT;
+    }
+
+    public function getScopeId(Order $order): int
+    {
+        if ($order->getStoreId()) {
+            // Use store ID if non-zero
+            return (int)$order->getStoreId();
+        } elseif ($order->getStore()->getWebsiteId()) {
+            // Otherwise use website ID if store ID == 0
+            return (int)$order->getStore()->getWebsiteId();
+        }
+        // Otherwise default scope ID = 0
+        return 0;
     }
 
     /**

--- a/Model/Order/Payment.php
+++ b/Model/Order/Payment.php
@@ -1,11 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Payplug\Payments\Model\Order;
 
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\DataObject\IdentityInterface;
+use Magento\Framework\Model\AbstractModel;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
 use Magento\Store\Model\ScopeInterface;
 use Payplug\Payments\Helper\Config;
+use Payplug\Resource\Payment as ResourcePayment;
+use Payplug\Resource\Refund;
 
-class Payment extends \Magento\Framework\Model\AbstractModel implements \Magento\Framework\DataObject\IdentityInterface
+class Payment extends AbstractModel implements IdentityInterface
 {
     public const CACHE_TAG = 'payplug_payments_order_payment';
 
@@ -28,29 +38,15 @@ class Payment extends \Magento\Framework\Model\AbstractModel implements \Magento
     public const SENT_BY_SMS = 'SMS';
     public const SENT_BY_EMAIL = 'EMAIL';
 
-    /**
-     * @var Config
-     */
-    private $payplugConfig;
-
-    /**
-     * @param \Magento\Framework\Model\Context                        $context
-     * @param \Magento\Framework\Registry                             $registry
-     * @param Config                                                  $payplugConfig
-     * @param \Magento\Framework\Model\ResourceModel\AbstractResource $resource
-     * @param \Magento\Framework\Data\Collection\AbstractDb           $resourceCollection
-     * @param array                                                   $data
-     */
     public function __construct(
-        \Magento\Framework\Model\Context $context,
-        \Magento\Framework\Registry $registry,
-        Config $payplugConfig,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        Context $context,
+        Registry $registry,
+        private Config $payplugConfig,
+        AbstractResource $resource = null,
+        AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
-        $this->payplugConfig = $payplugConfig;
     }
 
     /**
@@ -62,253 +58,198 @@ class Payment extends \Magento\Framework\Model\AbstractModel implements \Magento
     }
 
     /**
-     * Get entity identities
-     *
-     * @return array
+     * If the payment is still being processed
      */
-    public function getIdentities()
+    public function isProcessing(ResourcePayment $resourcePayment): bool
+    {
+        $isProcessing = (!$resourcePayment->is_paid && empty($resourcePayment->failure));
+
+        if ($isProcessing && $resourcePayment->getPaymentId) {
+            $this->_logger->info(sprintf('Payment payment_id %s is still processing.', $resourcePayment->getPaymentId));
+        }
+
+        return $isProcessing;
+    }
+
+    /**
+     * Get entity identities
+     */
+    public function getIdentities(): array
     {
         return [self::CACHE_TAG . '_' . $this->getId()];
     }
 
     /**
      * Get order id
-     *
-     * @return int
      */
-    public function getOrderId()
+    public function getOrderId(): int
     {
-        return $this->_getData(self::ORDER_ID);
+        return (int)$this->_getData(self::ORDER_ID);
     }
 
     /**
      * Set order id
-     *
-     * @param int $orderId
-     *
-     * @return $this
      */
-    public function setOrderId($orderId)
+    public function setOrderId(int $orderId): self
     {
         return $this->setData(self::ORDER_ID, $orderId);
     }
 
     /**
      * Get payment id
-     *
-     * @return string
      */
-    public function getPaymentId()
+    public function getPaymentId(): string
     {
         return $this->_getData(self::PAYMENT_ID);
     }
 
     /**
      * Set payment id
-     *
-     * @param string $paymentId
-     *
-     * @return $this
      */
-    public function setPaymentId($paymentId)
+    public function setPaymentId(string $paymentId): self
     {
         return $this->setData(self::PAYMENT_ID, $paymentId);
     }
 
     /**
      * Get is sandbox
-     *
-     * @return bool
      */
-    public function isSandbox()
+    public function isSandbox(): bool
     {
-        return (bool) $this->_getData(self::IS_SANDBOX);
+        return (bool)$this->_getData(self::IS_SANDBOX);
     }
 
     /**
      * Set is sandbox
-     *
-     * @param bool $isSandbox
-     *
-     * @return $this
      */
-    public function setIsSandbox($isSandbox)
+    public function setIsSandbox(bool $isSandbox): self
     {
         return $this->setData(self::IS_SANDBOX, $isSandbox);
     }
 
     /**
      * Get installment plan processed flag
-     *
-     * @return bool
      */
-    public function isInstallmentPlanPaymentProcessed()
+    public function isInstallmentPlanPaymentProcessed(): bool
     {
-        return (bool) $this->_getData(self::IS_INSTALLMENT_PLAN_PAYMENT_PROCESSED);
+        return (bool)$this->_getData(self::IS_INSTALLMENT_PLAN_PAYMENT_PROCESSED);
     }
 
     /**
      * Set installment plan processed flag
-     *
-     * @param bool $isProcessed
-     *
-     * @return $this
      */
-    public function setIsInstallmentPlanPaymentProcessed($isProcessed)
+    public function setIsInstallmentPlanPaymentProcessed(bool $isProcessed): self
     {
         return $this->setData(self::IS_INSTALLMENT_PLAN_PAYMENT_PROCESSED, $isProcessed);
     }
 
     /**
      * Get sent by
-     *
-     * @return string|null
      */
-    public function getSentBy()
+    public function getSentBy(): ?string
     {
         return $this->_getData(self::SENT_BY);
     }
 
     /**
      * Set sent by
-     *
-     * @param string|null $sentBy
-     *
-     * @return $this
      */
-    public function setSentBy($sentBy = null)
+    public function setSentBy(?string $sentBy = null): self
     {
         return $this->setData(self::SENT_BY, $sentBy);
     }
 
     /**
      * Get sent by value
-     *
-     * @return string|null
      */
-    public function getSentByValue()
+    public function getSentByValue(): ?string
     {
         return $this->_getData(self::SENT_BY_VALUE);
     }
 
     /**
      * Set sent by value
-     *
-     * @param string|null $sentByValue
-     *
-     * @return $this
      */
-    public function setSentByValue($sentByValue = null)
+    public function setSentByValue(?string $sentByValue = null): self
     {
         return $this->setData(self::SENT_BY_VALUE, $sentByValue);
     }
 
     /**
      * Get language
-     *
-     * @return string|null
      */
-    public function getLanguage()
+    public function getLanguage(): ?string
     {
         return $this->_getData(self::LANGUAGE);
     }
 
     /**
      * Set language
-     *
-     * @param string|null $language
-     *
-     * @return $this
      */
-    public function setLanguage($language = null)
+    public function setLanguage(?string $language = null): self
     {
         return $this->setData(self::LANGUAGE, $language);
     }
 
     /**
      * Get description
-     *
-     * @return string|null
      */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->_getData(self::DESCRIPTION);
     }
 
     /**
      * Set description
-     *
-     * @param string|null $description
-     *
-     * @return $this
      */
-    public function setDescription($description = null)
+    public function setDescription(?string $description = null): self
     {
         return $this->setData(self::DESCRIPTION, $description);
     }
 
     /**
-     * Retrive a payment
-     *
-     * @param int|null $store
-     *
-     * @return \Payplug\Resource\Payment
+     * Retrieve a payment
      */
-    public function retrieve($store = null, ?string $scope = ScopeInterface::SCOPE_STORE)
+    public function retrieve(?int $store = null, ?string $scope = ScopeInterface::SCOPE_STORE): ResourcePayment
     {
-        $this->payplugConfig->setPayplugApiKey((int)$store, $this->isSandbox(), $scope);
+        $this->payplugConfig->setPayplugApiKey($store, $this->isSandbox(), $scope);
 
         return \Payplug\Payment::retrieve($this->getPaymentId());
     }
 
     /**
      * Attempt to refund partially or totally a payment
-     *
-     * @param float    $amount
-     * @param array    $metadata
-     * @param int|null $store
-     *
-     * @return \Payplug\Resource\Refund
      */
-    public function makeRefund($amount, $metadata, $store = null)
+    public function makeRefund(float $amount, ?array $metadata, ?int $store = null): Refund
     {
         $data = [
             'amount' => $amount * 100,
             'metadata' => $metadata
         ];
 
-        $this->payplugConfig->setPayplugApiKey((int)$store, $this->isSandbox());
+        $this->payplugConfig->setPayplugApiKey($store, $this->isSandbox());
 
         return \Payplug\Refund::create($this->getPaymentId(), $data);
     }
 
     /**
      * Abort an installment plan
-     *
-     * @param int|null $store
-     *
-     * @return \Payplug\Resource\Payment
      */
-    public function abort($store = null)
+    public function abort(?int $store = null): ResourcePayment
     {
-        $this->payplugConfig->setPayplugApiKey((int)$store, $this->isSandbox());
+        $this->payplugConfig->setPayplugApiKey($store, $this->isSandbox());
 
         return \Payplug\Payment::abort($this->getPaymentId());
     }
 
     /**
      * Update a payment
-     *
-     * @param array    $data
-     * @param int|null $store
-     *
-     * @return \Payplug\Resource\Payment
      */
-    public function update(array $data, $store = null)
+    public function update(array $data, ?int $store = null): ResourcePayment
     {
-        $this->payplugConfig->setPayplugApiKey((int)$store, $this->isSandbox());
+        $this->payplugConfig->setPayplugApiKey($store, $this->isSandbox());
 
-        $payment = \Payplug\Resource\Payment::fromAttributes(['id' => $this->getPaymentId()]);
+        $payment = ResourcePayment::fromAttributes(['id' => $this->getPaymentId()]);
 
         return $payment->update($data);
     }

--- a/Model/Order/Payment.php
+++ b/Model/Order/Payment.php
@@ -66,8 +66,8 @@ class Payment extends AbstractModel implements IdentityInterface
     {
         $isProcessing = (!$resourcePayment->is_paid && empty($resourcePayment->failure));
 
-        if ($isProcessing && $resourcePayment->getPaymentId) {
-            $this->_logger->info(sprintf('Payment payment_id %s is still processing.', $resourcePayment->getPaymentId));
+        if ($isProcessing && isset($resourcePayment->id)) {
+            $this->_logger->info(sprintf('Payment payment_id %s is still processing.', $resourcePayment->id));
         }
 
         return $isProcessing;

--- a/Observer/CreditMemoCheckRefundedAmountObserver.php
+++ b/Observer/CreditMemoCheckRefundedAmountObserver.php
@@ -92,7 +92,7 @@ class CreditMemoCheckRefundedAmountObserver implements ObserverInterface
             }
 
             $payplugPayment = $this->helper->getOrderPayment($order->getIncrementId());
-            $payment = $payplugPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $payment = $payplugPayment->retrieve($payplugPayment->getScopeId($order), $payplugPayment->getScope($order));
 
             if ($order->getPayment()->getMethod() === Oney::METHOD_CODE ||
                 $order->getPayment()->getMethod() === OneyWithoutFees::METHOD_CODE

--- a/Observer/CreditMemoCheckRefundedAmountObserver.php
+++ b/Observer/CreditMemoCheckRefundedAmountObserver.php
@@ -92,7 +92,7 @@ class CreditMemoCheckRefundedAmountObserver implements ObserverInterface
             }
 
             $payplugPayment = $this->helper->getOrderPayment($order->getIncrementId());
-            $payment = $payplugPayment->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $payment = $payplugPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
 
             if ($order->getPayment()->getMethod() === Oney::METHOD_CODE ||
                 $order->getPayment()->getMethod() === OneyWithoutFees::METHOD_CODE

--- a/Observer/OrderCancelObserver.php
+++ b/Observer/OrderCancelObserver.php
@@ -56,7 +56,7 @@ class OrderCancelObserver implements ObserverInterface
         }
 
         try {
-            $lastOrderPayment->abort($order->getStoreId());
+            $lastOrderPayment->abort((int)$order->getStoreId());
         } catch (PayplugException $e) {
             $this->logger->error($e->__toString());
             throw new \Exception(__('Unable to abort payment %1', $lastOrderPayment->getPaymentId()));

--- a/Plugin/CaptureStandardDeferredPayment.php
+++ b/Plugin/CaptureStandardDeferredPayment.php
@@ -70,7 +70,7 @@ class CaptureStandardDeferredPayment
 
         try {
             $payplugPayment = $this->orderPaymentRepository->get($payplugPaymentId, 'payment_id');
-            $paymentCapture = $payplugPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $paymentCapture = $payplugPayment->retrieve($payplugPayment->getScopeId($order), $payplugPayment->getScope($order));
             $paymentObject = $paymentCapture->capture();
             if ($paymentObject) {
                 $magentoPayment->setBaseAmountPaidOnline((float)$quotePayment->getAdditionalInformation('authorized_amount') / 100);

--- a/Plugin/CaptureStandardDeferredPayment.php
+++ b/Plugin/CaptureStandardDeferredPayment.php
@@ -70,7 +70,7 @@ class CaptureStandardDeferredPayment
 
         try {
             $payplugPayment = $this->orderPaymentRepository->get($payplugPaymentId, 'payment_id');
-            $paymentCapture = $payplugPayment->retrieve($order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
+            $paymentCapture = $payplugPayment->retrieve((int)$order->getStore()->getWebsiteId(), ScopeInterface::SCOPE_WEBSITES);
             $paymentObject = $paymentCapture->capture();
             if ($paymentObject) {
                 $magentoPayment->setBaseAmountPaidOnline((float)$quotePayment->getAdditionalInformation('authorized_amount') / 100);

--- a/Service/GetCurrentOrder.php
+++ b/Service/GetCurrentOrder.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Payplug\Payments\Service;
+
+use Magento\Checkout\Model\Session;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\OrderFactory;
+use Payplug\Payments\Logger\Logger;
+
+class GetCurrentOrder
+{
+    public function __construct(
+        protected RequestInterface $request,
+        protected Session $checkoutSession,
+        protected OrderFactory $salesOrderFactory,
+        protected CartRepositoryInterface $cartRepositoryInterface,
+        protected Logger $logger
+    ) {
+    }
+
+    /**
+     * Attempt to retrieve the currently active order using multiple strategies.
+     *
+     * @throws \Exception
+     */
+    public function execute(): ?OrderInterface
+    {
+        // 1) Try to load via last real order increment ID
+        $order = $this->loadOrderByIncrementId(
+            $this->checkoutSession->getLastRealOrder()?->getIncrementId()
+        );
+
+        if ($order) {
+            return $order;
+        }
+
+        // 2) Try to load via the first available quote ID
+        $quoteId = $this->request->getParam('quote_id')
+            ?? $this->checkoutSession->getLastQuoteId()
+            ?? $this->checkoutSession->getQuoteId();
+
+        $order = $this->loadOrderByQuoteId($quoteId);
+
+        if ($order) {
+            return $order;
+        }
+
+        // If all attempts failed:
+        throw new \Exception('Could not retrieve last order id');
+    }
+
+    /**
+     * Helper method to load an order from a given increment ID, or return null if not found.
+     */
+    private function loadOrderByIncrementId(?string $incrementId): ?OrderInterface
+    {
+        if (!$incrementId) {
+            return null;
+        }
+
+        $order = $this->salesOrderFactory->create();
+        $order->loadByIncrementId($incrementId);
+
+        return $order->getId() ? $order : null;
+    }
+
+    /**
+     * Helper method to load an order from a quote's reserved order ID, or return null if not found.
+     *
+     * @throws NoSuchEntityException
+     */
+    private function loadOrderByQuoteId(?int $quoteId): ?OrderInterface
+    {
+        if (!$quoteId) {
+            return null;
+        }
+
+        $quote = $this->cartRepositoryInterface->get($quoteId);
+        $reservedOrderId = $quote->getReservedOrderId();
+
+        if (!$reservedOrderId) {
+            return null;
+        }
+
+        return $this->loadOrderByIncrementId($reservedOrderId);
+    }
+}

--- a/Service/GetCurrentOrder.php
+++ b/Service/GetCurrentOrder.php
@@ -44,7 +44,7 @@ class GetCurrentOrder
             ?? $this->checkoutSession->getLastQuoteId()
             ?? $this->checkoutSession->getQuoteId();
 
-        $order = $this->loadOrderByQuoteId($quoteId);
+        $order = $this->loadOrderByQuoteId((int)$quoteId);
 
         if ($order) {
             return $order;
@@ -76,7 +76,7 @@ class GetCurrentOrder
      */
     private function loadOrderByQuoteId(?int $quoteId): ?OrderInterface
     {
-        if (!$quoteId) {
+        if (!$quoteId || $quoteId == 0) {
             return null;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "payplug/payplug-magento2",
   "description": "[Release Candidate] Payplug Payments module for Magento 2",
   "type": "magento2-module",
-  "version": "4.3.0-rc",
+  "version": "4.3.0-RC",
   "license": [
     "OSL-3.0"
   ],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "payplug/payplug-magento2",
   "description": "Payplug Payments module for Magento 2",
   "type": "magento2-module",
-  "version": "4.3.0",
+  "version": "4.3.0-beta",
   "license": [
     "OSL-3.0"
   ],

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "payplug/payplug-magento2",
-  "description": "[Release Candidate] Payplug Payments module for Magento 2",
+  "description": "Payplug Payments module for Magento 2",
   "type": "magento2-module",
-  "version": "4.3.0-RC",
+  "version": "4.3.0",
   "license": [
     "OSL-3.0"
   ],

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "payplug/payplug-magento2",
-  "description": "Payplug Payments module for Magento 2",
+  "description": "[Release Candidate] Payplug Payments module for Magento 2",
   "type": "magento2-module",
-  "version": "4.3.0-beta",
+  "version": "4.3.0-rc",
   "license": [
     "OSL-3.0"
   ],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "payplug/payplug-magento2",
   "description": "Payplug Payments module for Magento 2",
   "type": "magento2-module",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "license": [
     "OSL-3.0"
   ],

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -5,5 +5,8 @@
         <job name="payplug_payments_auto_capture_deferred_payments" instance="Payplug\Payments\Cron\AutoCaptureDeferredPayments" method="execute">
             <schedule>0 * * * *</schedule>
         </job>
+        <job name="payplug_payments_check_order_consistency" instance="Payplug\Payments\Cron\CheckOrderConsistency" method="execute">
+            <schedule>*/15 * * * *</schedule>
+        </job>
     </group>
 </config>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -3,33 +3,38 @@
     <policies>
         <policy id="script-src">
             <values>
-                <value id="apple-pay" type="host">applepay.cdn-apple.com</value>
-                <value id="payplug-api" type="host">api-qa.payplug.com</value>
-                <value id="payplug-script-cd-qa" type="host">cdn-qa.payplug.com</value>
-                <value id="payplug-script-qa" type="host">https://cdn-qa.payplug.com</value>
-                <value id="secure-magenta" type="host">https://secure-magenta.dalenys.com</value>
+                <value id="payplug-apple-pay" type="host">applepay.cdn-apple.com</value>
+                <value id="payplug-api-qa" type="host">api-qa.payplug.com</value>
+                <value id="payplug-cdn-qa" type="host">cdn-qa.payplug.com</value>
+                <value id="payplug-secure-magenta" type="host">https://secure-magenta.dalenys.com</value>
+                <value id="payplug-cdn" type="host">cdn.payplug.com</value>
             </values>
         </policy>
         <policy id="style-src">
             <values>
-                <value id="secure-magenta" type="host">https://secure-magenta.dalenys.com</value>
+                <value id="payplug-secure-magenta" type="host">https://secure-magenta.dalenys.com</value>
             </values>
         </policy>
-         <policy id="frame-src">
+        <policy id="frame-src">
             <values>
-                <value id="api_payplug" type="host">api-qa.payplug.com</value>
-                <value id="secure_payplug" type="host">secure-qa.payplug.com</value>
-                <value id="spayplug" type="host">*.payplug.com</value>
+                <value id="payplug-api-qa" type="host">api-qa.payplug.com</value>
+                <value id="payplug-secure-qa" type="host">secure-qa.payplug.com</value>
+                <value id="payplug-all" type="host">*.payplug.com</value>
             </values>
         </policy>
         <policy id="font-src">
-          <values>
-            <value id="apple-pay" type="host">applepay.cdn-apple.com</value>
-          </values>
+            <values>
+                <value id="payplug-apple-pay" type="host">applepay.cdn-apple.com</value>
+            </values>
         </policy>
         <policy id="img-src">
             <values>
-                <value id="secure-magenta" type="host">https://secure-magenta.dalenys.com</value>
+                <value id="payplug-secure-magenta" type="host">https://secure-magenta.dalenys.com</value>
+            </values>
+        </policy>
+        <policy id="script-src-elem">
+            <values>
+                <value id="payplug-cdn" type="host">cdn.payplug.com</value>
             </values>
         </policy>
     </policies>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -3,10 +3,11 @@
     <policies>
         <policy id="script-src">
             <values>
+                <value id="payplug-secure-magenta" type="host">https://secure-magenta.dalenys.com</value>
                 <value id="payplug-apple-pay" type="host">applepay.cdn-apple.com</value>
                 <value id="payplug-api-qa" type="host">api-qa.payplug.com</value>
                 <value id="payplug-cdn-qa" type="host">cdn-qa.payplug.com</value>
-                <value id="payplug-secure-magenta" type="host">https://secure-magenta.dalenys.com</value>
+                <value id="payplug-api" type="host">api.payplug.com</value>
                 <value id="payplug-cdn" type="host">cdn.payplug.com</value>
             </values>
         </policy>
@@ -18,7 +19,9 @@
         <policy id="frame-src">
             <values>
                 <value id="payplug-api-qa" type="host">api-qa.payplug.com</value>
+                <value id="payplug-api" type="host">api.payplug.com</value>
                 <value id="payplug-secure-qa" type="host">secure-qa.payplug.com</value>
+                <value id="payplug-secure" type="host">secure.payplug.com</value>
                 <value id="payplug-all" type="host">*.payplug.com</value>
             </values>
         </policy>
@@ -34,6 +37,7 @@
         </policy>
         <policy id="script-src-elem">
             <values>
+                <value id="payplug-cdn-qa" type="host">cdn-qa.payplug.com</value>
                 <value id="payplug-cdn" type="host">cdn.payplug.com</value>
             </values>
         </policy>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -18,11 +18,8 @@
         </policy>
         <policy id="frame-src">
             <values>
-                <value id="payplug-api-qa" type="host">api-qa.payplug.com</value>
-                <value id="payplug-api" type="host">api.payplug.com</value>
-                <value id="payplug-secure-qa" type="host">secure-qa.payplug.com</value>
-                <value id="payplug-secure" type="host">secure.payplug.com</value>
                 <value id="payplug-all" type="host">*.payplug.com</value>
+                <value id="dalenys-all" type="host">*.dalenys.com</value>
             </values>
         </policy>
         <policy id="font-src">
@@ -33,12 +30,6 @@
         <policy id="img-src">
             <values>
                 <value id="payplug-secure-magenta" type="host">https://secure-magenta.dalenys.com</value>
-            </values>
-        </policy>
-        <policy id="script-src-elem">
-            <values>
-                <value id="payplug-cdn-qa" type="host">cdn-qa.payplug.com</value>
-                <value id="payplug-cdn" type="host">cdn.payplug.com</value>
             </values>
         </policy>
     </policies>

--- a/view/frontend/templates/checkout/formjs.phtml
+++ b/view/frontend/templates/checkout/formjs.phtml
@@ -3,16 +3,17 @@
 declare(strict_types=1);
 
 use Magento\Framework\Escaper;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
 use Payplug\Payments\Block\Formjs;
 
 /**
  * @var Escaper $escaper
  * @var Formjs $block
+ * @var SecureHtmlRenderer $secureRenderer
  */
 ?>
 <?php foreach ($block->getJsUrls() as $url): ?>
-    <script src="<?= $escaper->escapeUrl($url); ?>"></script>
+    <?= $secureRenderer->renderTag('script', ['src' => $escaper->escapeUrl($url)], '', false); ?>
 <?php endforeach; ?>
-<script>
-window.PAYPLUG_DOMAIN = '<?= $block->getPayplugSecureUrl(); ?>';
-</script>
+<?php $scriptContent = 'window.PAYPLUG_DOMAIN = \'' . $escaper->escapeUrl($block->getPayplugSecureUrl()) . '\';' ?>
+<?= $secureRenderer->renderTag('script', [], $scriptContent, false); ?>

--- a/view/frontend/templates/info/installment_plan.phtml
+++ b/view/frontend/templates/info/installment_plan.phtml
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Payplug\Payments\Block\InstallmentPlanInfo;
+
+/**
+ * @var Escaper $escaper
+ * @var InstallmentPlanInfo $block
+ */
+$specificInfo = $block->getSpecificInformation();
+$title = $escaper->escapeHtml($block->getMethod()->getTitle());
+?>
+    <dl class="payment-method">
+        <dt class="title"><?= /* @noEscape */ $title ?></dt>
+        <?php if ($specificInfo): ?>
+            <dd class="content">
+                <table class="data table">
+                    <caption class="table-caption"><?= /* @noEscape */ $title ?></caption>
+                    <?php foreach ($specificInfo as $label => $value): ?>
+                        <tr>
+                            <th scope="row"><?= $escaper->escapeHtml($label) ?></th>
+                            <td>
+                                <?php
+                                $formattedValue = implode(PHP_EOL, $block->getValueAsArray($value, true));
+                                ?>
+                                <?= /* @noEscape */ nl2br($escaper->escapeHtml($formattedValue)) ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </table>
+            </dd>
+        <?php endif;?>
+    </dl>
+<?= $block->getChildHtml() ?>


### PR DESCRIPTION
## [4.3.0](https://github.com/payplug/payplug-magento2/releases/tag/v4.3.0) - 2025-03-19

### Features

- Support Magento 2.4.7
- Add a queue system feature 
- Synchronize orders status with Payplug servers post payment 
- Compatibility with php 8.1 and Magento 2.4.4 and above. (SMP-3032)

**[View diff](https://github.com/payplug/payplug-magento2/compare/v4.2.0...release/v4.3.0)**

### Added

- Add queue system payment feature [#246](https://github.com/payplug/payplug-magento2/pull/246)

### Removed

- Removed the unions type in the base code. [#246](https://github.com/payplug/payplug-magento2/pull/246)

### Fixed

- Fix the scripts for the 2.4.7 with the secureHtmlRenderer class [#253](https://github.com/payplug/payplug-magento2/pull/253)