### PR TITLE
Fix return type

### DIFF
--- a/Block/Adminhtml/Config/Oauth2Logout.php
+++ b/Block/Adminhtml/Config/Oauth2Logout.php
@@ -110,7 +110,7 @@ HTML;
 
     private function getCurrentWebsite(): ?int
     {
-        return $this->getRequest()->getParam('website') ?: null;
+        return (int)$this->getRequest()->getParam('website') ?: null;
     }
 
     private function isDeveloperMode(): bool


### PR DESCRIPTION
Fix return type and error:

TypeError: Payplug\Payments\Block\Adminhtml\Config\Oauth2Logout::getCurrentWebsite(): Return value must be of type ?int, string returned in /datas/preprod/vendor/payplug/payplug-magento2/Block/Adminhtml/Config/Oauth2Logout.php:113

# ⚠️ Requirements
Reviewer, please take a look at those requirements before merging on `master` :

- [x] Check that plugin version has been upgrated and are identical in both `composer.json` and `Helper/Config.php` files

