### PR TITLE
Fixes an inconsistent array key in PaymentConfigObserver.php

### DIFF
--- a/Observer/PaymentConfigObserver.php
+++ b/Observer/PaymentConfigObserver.php
@@ -53,6 +53,10 @@ class PaymentConfigObserver implements ObserverInterface
             return;
         }
 
+        if (!isset($postParams['groups'])) {
+            return;
+        }
+
         $groups = $postParams['groups'];
 
         $sections = $postParams['config_state'];


### PR DESCRIPTION
For example: section config with only image field do not have group. If module has a section config with only image fields. Payplug Observer create an exception.

# ⚠️ Requirements
Reviewer, please take a look at those requirements before merging on `master` :

- [x] Check that plugin version has been upgrated and are identical in both `composer.json` and `Helper/Config.php` files

