### PR TITLE
MAG-598: Allow compatibility with giggsey/libphonenumber-for-php 9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "magento/module-checkout": "100.3.*|100.4.*",
     "magento/module-sales": "102.0.*|103.0.*",
     "payplug/payplug-php": "^4.0.0",
-    "giggsey/libphonenumber-for-php": "^8.10",
+    "giggsey/libphonenumber-for-php": "^8.10|^9.0",
     "ext-openssl": "*"
   },
   "autoload": {


### PR DESCRIPTION
# ⚠️ Requirements
Reviewer, please take a look at those requirements before merging on `master` :

- [ ] Check that plugin version has been upgrated and are identical in both `composer.json` and `Helper/Config.php` files

