### PR TITLE
$fields is missing params from the general group

### DIFF
--- a/Observer/PaymentConfigObserver.php
+++ b/Observer/PaymentConfigObserver.php
@@ -141,7 +141,7 @@ class PaymentConfigObserver implements ObserverInterface
      */
     private function processGeneralConfig(array &$groups): void
     {
-        $authFields = $fields = $groups['auth']['fields'];
+        $authFields = $fields = array_merge($groups['general']['fields'], $groups['auth']['fields']);
 
         if (empty($fields['email']) && !empty($authFields['email'])) {
             $fields['email'] = $authFields['email'];


### PR DESCRIPTION
Later in checkRequiredFields(), the $fields array is checked and the param environmentmode needs to exist. However $fields is initialized with params from auth group. The param 'environmentmode' in the general group is then missing while it's required in $fieldsRequiredForInit.

Version is 4.6.2

