### PR TITLE
MAG-751: Remove hardcoded countries overrides for Bizum and Wero

### DIFF
--- a/Service/GetAllowedCountriesPerPaymentMethod.php
+++ b/Service/GetAllowedCountriesPerPaymentMethod.php
@@ -38,6 +38,10 @@ class GetAllowedCountriesPerPaymentMethod
             $this->payplugConfigHelper->getConfigValue($paymentMethod . '_countries') ?? '[]'
         );
 
+        /**
+         * Accepted technical debt: the hardcoded configuration remains in place for the four legacy APMs :
+         * IDEAL, BANCONTACT, MYBANK and SATISPAY
+         */
         $restrictedCountryOverrideIds = $this->serializer->unserialize(
             $this->payplugConfigHelper->getConfigValue($paymentMethod . '_countries_override') ?? '[]'
         );

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -389,8 +389,6 @@
                 <ideal_countries_override>["NL"]</ideal_countries_override>
                 <mybank_countries_override>["IT"]</mybank_countries_override>
                 <satispay_countries_override>["IT"]</satispay_countries_override>
-                <bizum_countries_override>["ES"]</bizum_countries_override>
-                <wero_countries_override>["BE","FR","DE","NL","AT"]</wero_countries_override>
             </general>
         </payplug_payments>
     </default>


### PR DESCRIPTION
# ⚠️ Requirements
Reviewer, please take a look at those requirements before merging on `master` :

- [ ] Check that plugin version has been upgrated and are identical in both `composer.json` and `Helper/Config.php` files

